### PR TITLE
Documentation for the trial for Cloud Foundry

### DIFF
--- a/CloudFoundry/configure.html
+++ b/CloudFoundry/configure.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Configuring your machine to use the Government PaaS</h1>
+    <p>
+      Configuring your machine is as easy as installing the correct CLI - start here: <a href="https://github.com/cloudfoundry/cli#downloads">https://github.com/cloudfoundry/cli#downloads</a>
+    </p>
+    <p>
+      Once you have downloaded and installed the CLI client for your OS you should be able to login to the environment using the following:
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+      <p>
+        $ cf login --skip-ssl-validation
+      </p>
+      <p>
+        API endpoint>  https://api.trial.cf.paas.alphagov.co.uk/
+      </p>
+      <p>
+        Email> your@email.gov.uk
+      </p>
+      <p>
+        Password> yourpassword
+      </p>
+    </span>
+    <p>
+      Now that you're setup head on over to the <a href="samples.html">samples</a> to try deploying an application.
+  </body>
+</html>

--- a/CloudFoundry/index.html
+++ b/CloudFoundry/index.html
@@ -1,0 +1,35 @@
+
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px; ">
+
+  	<h1>Welcome to the Government PaaS trial</h1>
+  	<div>
+  		<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.6; margin-top: 2em;">
+  			<li><a href="./configure.html">How to configure your machine to use the Government PaaS</a></li>
+  			<li><a href="./samples.html">Some sample applications and instructions for deploying an app</a>. These apps give examples of how to perform a range of different functions within the platform.</li>
+  			<li><a href="./list.html">List of things to try during the trial</a> - trial participants who complete the bucket list and give us feedback are in line for a prize!</li>
+  		</ul>
+  	</div>
+	<div style="margin-top: 2em; margin-bottom: 2em;">
+		Please feel free to use the PaaS to deploy apps, connect to backing services and generally use this environment to experiment and try things out - deployment is quick and easy so there's nothing stopping you! 
+	</div>
+	<div style="margin-top: 2em;">
+		Please take note of the the following while you are using the trial environment: 
+	</div>
+	<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.8;">
+		<li>We haven't built out the security as we would like yet so please don't deploy any production data - we can't guarantee its security.</li>
+		<li>This is not yet a production build so please don't use anything deployed on the trial as part of a production installation - we cannot guarantee system availability</li>
+		<li>We will make every effort to ensure that the environment is continuously available but we cannot guarantee this</li>
+		<li>We will make every effort to ensure that we don't remove / kill any applications that have been deployed to the environment but we cannot guarantee that an upgrade or rebuild will not require us to do this</li>
+		<li>We will endeavour to keep all participants up to date with the latest information about the status of the trial</li>
+		<li>If you require support please send an email to <a href="mailto:support@governmentpaas.zendesk.com">support@governmentpaas.zendesk.com</a>. We will aim to resolve all tickets within 4 business hours - let us know how we do.</li>
+	</ul>
+  </body>
+</html>

--- a/CloudFoundry/list.html
+++ b/CloudFoundry/list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Here's a list of things to try out:</h1>
+  	<div>
+  		<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.6; margin-top: 2em;">
+  			<li>Deploy an application</li>
+  			<li>Bind an application to a backing service (Postgres / Redis)</li>
+  			<li>Scale the number of instances of your app (up and down)</li>
+  			<li>Connect to your application from the outside world to ensure it works</li>
+  			<li>Drive traffic to your application (if you have the tools to do this)</li>
+  			<li>Perform a zero-downtime deploy of a new version of your app (for bonus points try this with traffic being driven to the app at the same time)</li>
+  			<li>Remove your app</li>
+  		</ul>
+  	</div>
+	<div style="margin-top: 2em; margin-bottom: 2em;">
+		Remember to give us feedback on how you get on and improvements that we should make!
+	</div>
+  </body>
+</html>
+
+
+
+
+
+
+
+

--- a/CloudFoundry/samples.html
+++ b/CloudFoundry/samples.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-bottom-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Deploying some sample apps</h1>
+    <p>
+      To make life a little easier for trialling our PaaS options, here’s a selection of sample applications which should help when getting started with the platforms.
+    </p>
+    <p>
+      <em>Note:</em> Because this is a shared environment if your attempt to create an app may fail if one already exists with the same name. You can simply append something unique - like your name - in order to overcome this. There are ways to configure domains that will allow apps with the same names across teams but this is a more advanced topic than this document is intended to cover.
+    </p>
+    <h2>Spring Music :</h2>
+    <p>
+    	A simple java app using the Spring Framework for managing your record collection. This application supports working with a variety of different database backends - the default deployment uses a simple in-memory database.
+    </p>
+
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		git clone https://github.com/cloudfoundry-samples/spring-music.git
+	    </p>
+		<p>
+			cd spring-music
+		</p>
+		<p>
+			./gradlew assemble
+		</p>
+		<p>
+			cf push
+		</p>
+	</span>
+	<p>
+		The app is deployed using an in-memory database with a ${random-word} in it’s URL:
+	</p>
+	<p>
+		The <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">cf apps </span>command will list the URLs associated with the app.
+	</p>
+	<p>
+		To switch from in-memory database to a postgresql backend:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			cf marketplace # view the services available
+		</p>
+		<p>
+			cf create-service Postgresql "Basic PostgreSQL Plan" my_spring_db
+		</p>
+		<p>
+			cf bind-service spring-music my_spring_db
+		</p>
+		<p>
+			cf restart spring-music # restart the app to detect the new db service
+		</p>
+    </span>
+    <p>
+    	Now that the application is using a postgreSQL database backend, you may wish to scale up the number of deployed app instances as follows.
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	cf scale -i 2 spring-music # run two instances of the app
+    </span>
+    <p>
+    	You should now find that both instances of the app return the same data every time. The load balancer will round-robin connections between the different instances, so hitting shift-refresh in your browser a couple of times will switch between deployed instances. 
+    </p>
+    <h2>Flask SQLAlchemy Sample App :</h2>
+    <p>
+    	A simple microblog app built using Python/Flask using SQLAlchemy to support a postgres DB backend. The default <b>username / password </b> for the flask-sqlalchemy app is <b>admin / default</b>
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		git clone https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example.git
+    	</p>
+		<p>
+			cd flask-sqlalchemy-postgres-heroku-example
+		</p>
+		<p>
+			cf push flask_app --no-start
+		</p>
+	</span>
+	<p>
+		The Flask-sqlalchemy application requires a backend data service to run, so you will need to create a service instance of postgresql and bind it to the application as follows.
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		cf marketplace # view the services available
+    	</p>
+    	<p>
+    		cf create-service Postgresql "Basic PostgreSQL Plan" my_flaskapp_db
+    	</p>
+    	<p>
+    		cf bind-service flask_app my_flaskapp_db
+    	</p>
+    	<p>
+    		cf restart flask_app # restart the app to detect the new db service
+    	</p>
+    </span>
+    <p>
+    	The <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">cf apps</span> command will list the URLs associated with the app.
+    </p>
+    <p>
+    	The flask-sqlalchemy application supports running multiple instances and can be scaled using:
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>cf scale -i 3 flask_app # run three instances of the app</p>
+    </span>
+    <h2>Etherpad-lite Sample App :</h2>
+    <p>
+    	Etherpad is a real-time collaborative document editing app built using nodeJS. The master branch of the github source for Etherpad was not working at the time this document was written, so you’ll need to download a tagged release from the releases page.	
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		wget https://github.com/cloudfoundry-community/etherpad-lite-cf/releases/download/1.5.7-cf/etherpad-lite-cf.zip
+    	</p>
+		<p>
+			mkdir etherpad
+		</p>
+		<p>
+			cd etherpad
+		</p>
+		<p>
+			unzip ../etherpad-lite-cf.zip
+		</p>
+		<p>
+			cf push etherpad-lite -m 512M 
+		</p>
+		<p>
+			# The -m flag allows you to configures the amount of allocated memory
+		</p>
+	</span>
+	<p>
+		The <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">cf apps</span> command will list the URLs associated with the app.
+	</p>
+	<p>
+		The etherpad application does not support running more than one instance as there is no shared backend data service support, so if you attempt to scale this app to multiple instances then they will not all share the same data.
+	</p>
+	<h2>
+		Next steps...
+	</h2>
+	<p>
+		Now that you're familiar with the platform why not try ticking off all the items on our <a href="list.html">list</a> of tasks to try out on the platform.
+	</p>
+  </body>
+</html>
+


### PR DESCRIPTION
A set of static pages that have all the documentation for the trial.
The purpose of this is to have the trial documentation hosted on the
trial platform so we can keep it up to date. We will provide trial
participants with a link in their welcome email.
