### PR TITLE
Create Tsuru documentation

### DIFF
--- a/Tsuru/configure.html
+++ b/Tsuru/configure.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Configuring your machine to use the Government PaaS</h1>
+    <p>
+      Configuring your machine is as easy as installing the correct CLI - start here: <a href="http://docs.tsuru.io/en/stable/using/install-client.html">http://docs.tsuru.io/en/stable/using/install-client.html</a>
+    </p>
+    <p>
+      Tsuru has 3 different apps that can be downloaded (crane, tsuru, tsuru-admin) you will <b>only</b> need the tsuru app.
+    </p>
+    <p>
+      For OSX you should download the darwin_amd64 binary.
+    </p>
+    <p>
+      Once you have downloaded and installed the CLI client for your OS you should be able to login to the environment using the following:
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+      <p>
+        $  tsuru target-add trial https://trial-api.tsuru.paas.alphagov.co.uk -s
+      </p>
+      <p>
+        $  tsuru login
+      </p>
+      <p>
+        Email: your@email.gov.uk
+      </p>
+      <p>
+        Password: yourpassword
+      </p>
+    </span>
+    <p>
+      Now that you're setup head on over to the <a href="samples.html">samples</a> to try deploying an application.
+  </body>
+</html>

--- a/Tsuru/index.html
+++ b/Tsuru/index.html
@@ -1,0 +1,35 @@
+
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px; ">
+
+  	<h1>Welcome to the Government PaaS trial</h1>
+  	<div>
+  		<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.6; margin-top: 2em;">
+  			<li><a href="./configure.html">How to configure your machine to use the Government PaaS</a></li>
+  			<li><a href="./samples.html">Some sample applications and instructions for deploying an app</a>. These apps give examples of how to perform a range of different functions within the platform.</li>
+  			<li><a href="./list.html">List of things to try during the trial</a> - trial participants who complete the bucket list and give us feedback are in line for a prize!</li>
+  		</ul>
+  	</div>
+	<div style="margin-top: 2em; margin-bottom: 2em;">
+		Please feel free to use the PaaS to deploy apps, connect to backing services and generally use this environment to experiment and try things out - deployment is quick and easy so there's nothing stopping you! 
+	</div>
+	<div style="margin-top: 2em;">
+		Please take note of the the following while you are using the trial environment: 
+	</div>
+	<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.8;">
+		<li>We haven't built out the security as we would like yet so please don't deploy any production data - we can't guarantee its security.</li>
+		<li>This is not yet a production build so please don't use anything deployed on the trial as part of a production installation - we cannot guarantee system availability</li>
+		<li>We will make every effort to ensure that the environment is continuously available but we cannot guarantee this</li>
+		<li>We will make every effort to ensure that we don't remove / kill any applications that have been deployed to the environment but we cannot guarantee that an upgrade or rebuild will not require us to do this</li>
+		<li>We will endeavour to keep all participants up to date with the latest information about the status of the trial</li>
+		<li>If you require support please send an email to <a href="mailto:support@governmentpaas.zendesk.com">support@governmentpaas.zendesk.com</a>. We will aim to resolve all tickets within 4 business hours - let us know how we do.</li>
+	</ul>
+  </body>
+</html>

--- a/Tsuru/list.html
+++ b/Tsuru/list.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Here's a list of things to try out:</h1>
+  	<div>
+  		<ul style="list-style: disc outside none; margin-left: 100; padding-left: 3em;line-height: 1.6; margin-top: 2em;">
+  			<li>Deploy an application</li>
+  			<li>Bind an application to a backing service (Postgres / Redis)</li>
+  			<li>Scale the number of instances of your app (up and down)</li>
+  			<li>Connect to your application from the outside world to ensure it works</li>
+  			<li>Drive traffic to your application (if you have the tools to do this)</li>
+  			<li>Perform a zero-downtime deploy of a new version of your app (for bonus points try this with traffic being driven to the app at the same time)</li>
+  			<li>Remove your app</li>
+  		</ul>
+  	</div>
+	<div style="margin-top: 2em; margin-bottom: 2em;">
+		Remember to give us feedback on how you get on and improvements that we should make!
+	</div>
+  </body>
+</html>
+
+
+
+
+
+
+
+

--- a/Tsuru/samples.html
+++ b/Tsuru/samples.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Language" content="en">
+    <meta name="viewport" content="width=1020">
+  </head>
+  <body style="font-family:verdana; border-style: solid; border-top-width: 50px; border-left-width: 200px; border-bottom-width: 200px; border-color: #FFFFFF; border-right-width: 300px;  border-bottom-width: 200px;">
+
+  	<h1>Deploying some sample apps</h1>
+    <p>
+      To make life a little easier for trialling our PaaS options, here’s a selection of sample applications which should help when getting started with the platforms.
+    </p>
+    <p>
+      <em>Note:</em> Because this is a shared environment if your attempt to create an app may fail if one already exists with the same name. You can simply append something unique - like your name - in order to overcome this. There are ways to configure domains that will allow apps with the same names across teams but this is a more advanced topic than this document is intended to cover.
+    </p>
+    <h2>Spring Music :</h2>
+    <p>
+    	A simple java app using the Spring Framework for managing your record collection. This application supports working with a variety of different database backends - the default deployment uses a simple in-memory database.
+    </p>
+
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		git clone https://github.com/cloudfoundry-samples/spring-music.git
+	    </p>
+		<p>
+			cd spring-music
+		</p>
+	</span>
+	<p>
+		Create a tsuru.yaml file with the following contents:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			hooks:
+		</p>
+		<p>
+	  		build:
+	  	</p>
+	  	<p>
+  	    	- ./gradlew assemble
+  	    </p>
+  	    	- mv build/libs/spring-music.war ROOT.war
+		</p>
+	</span>
+	<p>
+		Finally create an app instance in Tsuru and deploy:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			tsuru app-create spring-music java
+		</p>
+		<p>
+			tsuru app-deploy .
+		</p>
+	</span>
+	<p>
+		Alternatively, you can build locally and only push (deploy) the war file:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			git clone https://github.com/cloudfoundry-samples/spring-music.git
+		</p>
+		<p>
+			cd spring-music
+		</p>
+		<p>
+			./gradlew assemble
+		</p>
+		<p>
+			mv build/libs/spring-music.war ROOT.war
+		</p>
+		<p>
+			tsuru app-create spring-music java
+		</p>
+		<p>
+			tsuru app-deploy ROOT.war
+		</p>
+	</span>
+    <h2>Flask SQLAlchemy Sample App :</h2>
+    <p>
+    	A simple microblog app built using Python/Flask using SQLAlchemy to support a postgres DB backend. The default <b>username / password </b> for the flask-sqlalchemy app is <b>admin / default</b>
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		git clone https://github.com/alphagov/flask-sqlalchemy-postgres-heroku-example.git
+    	</p>
+		<p>
+			cd flask-sqlalchemy-postgres-heroku-example
+		</p>
+		<p>
+			tsuru app-create flask python
+		</p>
+		<p>
+			tsuru service-add postgresql flasksql shared
+		</p>
+		<p>
+			tsuru service-bind flasksql -a flask
+		</p>
+		<p>
+			tsuru app-deploy . -a flask
+		</p>
+	</span>
+	<p>
+		To scale application up in tsuru by X instances, use:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		tsuru unit-add <X> -a flask
+    	</p>
+    </span>
+	<p>
+		To scale application down by X instances, use:
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		tsuru unit-remove <X> -a flask
+    	</p>
+    </span>
+    <p>
+    	The <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">cf apps</span> command will list the URLs associated with the app.
+    </p>
+
+    <h2>Etherpad-lite Sample App :</h2>
+    <p>
+    	Etherpad is a real-time collaborative document editing app built using nodeJS. The master branch of the github source for Etherpad was not working at the time this document was written, so you’ll need to download a tagged release from the releases page.	
+    </p>
+    <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+    	<p>
+    		wget https://github.com/cloudfoundry-community/etherpad-lite-cf/releases/download/1.5.7-cf/etherpad-lite-cf.zip
+    	</p>
+		<p>
+			mkdir etherpad
+		</p>
+		<p>
+			cd etherpad
+		</p>
+		<p>
+			unzip ../etherpad-lite-cf.zip
+		</p>
+	</span>
+	<p>
+		edit <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">bin/installDeps.sh.</span> Remove or comment out this section (lines 53-58):
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			#if [ ! $NODE_V_MINOR = "v0.10" ] && [ ! $NODE_V_MINOR = "v0.11" ] && [ ! $NODE_V_MINOR = "v0.12" ]; then
+		</p>
+		<p>
+			#  if [ ! $IOJS_VERSION ]; then
+		</p>
+		<p>
+			#    echo "You're running a wrong version of node, or io.js is not installed. You're using $NODE_VERSION, we need v0.10.x, v0.11.x or v0.12.x" >&2
+		</p>
+		<p>
+			#    exit 1
+		</p>
+		<p>
+			#  fi
+		</p>
+		<p>
+			#fi
+		</p>
+	</span>
+	<p>
+		edit <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">package.json</span> to add a <span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">license</span> field at the end (note the comma placement)
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			},
+		</p>
+		<p>
+			"version": "1.5.7-cf",
+		</p>
+		<p>
+			"license": "Apache-2.0"
+		</p>
+		<p>
+			}
+		</p>
+	</span>
+	<p>
+		Then run
+	</p>
+	<span style="font-size:13.3333333333333px;font-family:'Courier New';vertical-align:baseline;background-color:transparent">
+		<p>
+			bin/installDeps.sh 
+		</p>
+		<p>
+			tsuru app-create etherpad nodejs
+		</p>
+		<p>
+			tsuru app-deploy .
+		</p>
+	</span>
+	<p>
+		The etherpad application does not support running more than one instance as there is no shared backend data service support, so if you attempt to scale this app to multiple instances then they will not all share the same data.
+	</p>
+	<h2>
+		Next steps...
+	</h2>
+	<p>
+		Now that you're familiar with the platform why not try ticking off all the items on our <a href="list.html">list</a> of tasks to try out on the platform.
+	</p>
+  </body>
+</html>
+


### PR DESCRIPTION
A set of static pages that have all the documentation for the trial.
The purpose of this is to have the trial documentation hosted on the
trial platform so we can keep it up to date. We will provide trial
participants with a link in their welcome email.
