### PR TITLE
Fix support mailto link

### DIFF
--- a/CloudFoundry/content/index.md
+++ b/CloudFoundry/content/index.md
@@ -9,4 +9,4 @@ Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for
 ## Help!
 
 - Find the section you need on the left. 
-- Reach out with our support email [support@governmentpaas.zendesk.com](support@governmentpaas.zendesk.com).
+- Reach out with our support email <support@governmentpaas.zendesk.com>.

--- a/CloudFoundry/public/index.html
+++ b/CloudFoundry/public/index.html
@@ -150,7 +150,7 @@
 
 <ul>
 <li>Find the section you need on the left.</li>
-<li>Reach out with our support email <a href="support@governmentpaas.zendesk.com">support@governmentpaas.zendesk.com</a>.</li>
+<li>Reach out with our support email <a href="mailto:support@governmentpaas.zendesk.com">support@governmentpaas.zendesk.com</a>.</li>
 </ul>
 
     


### PR DESCRIPTION
This was being treated as a relative link which expanded tp:
- https://documentation.dcarley.cf.paas.alphagov.co.uk/support@governmentpaas.zendesk.com

Wrapping it with `<>` does the right thing in making it a `mailto:` link
with the same text.

Fixes Zendesk ticket:
- https://governmentpaas.zendesk.com/agent/tickets/6

---

I assume that I submit the rendered files too? Who has been deploying this to the trial environment?
