### PR TITLE
Tidied up some irregularities with the documentation

### DIFF
--- a/CloudFoundry/content/getting-started/concepts.md
+++ b/CloudFoundry/content/getting-started/concepts.md
@@ -75,10 +75,6 @@ cf target -o ORGNAME -s SPACENAME
 All apps need to use a 'buildpack' specific to their language, which sets up dependencies for particular language stacks. There are standard buildpacks for most lanugages, and they will usually be auto-detected by CF. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the manifest (as below) or with the `-b` flag. Use either the buildpack name:
 
     buildpack: python_buildpack
-    
-or a URL to reference it.
-
-    buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 
 To see a list of buildpacks that are available on the platform you can use:
 

--- a/CloudFoundry/content/index.md
+++ b/CloudFoundry/content/index.md
@@ -4,7 +4,15 @@ type: index
 
 # Govt PaaS Cloud Foundry Documentation
 
-Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for managing the deployment of apps, services, and background tasks. GDS is planning to use it for many of our development and production systems.
+Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for managing the deployment of apps, services, and background tasks. GDS is planning to use it for many of our development and production systems as well as opening it up to any other agencies and departments who want to take advantage of it.
+
+*Note:* We are currently trialling this with a non-production build in order to get as much feedback as possible and ensure we build the right thing for you. Because of this we recommend that:
+
+- you don't deploy any production apps or services
+- you don't put any production data onto the platform
+- you don't rely on the platform being available 100%
+
+We are working to make the platform production ready.
 
 ## Help!
 


### PR DESCRIPTION
Continuous Deployment and Multiple buildpacks pages were removed
because we have not yet tested them or our testing indicated that there
were some issues with these.

Updated the home page to include a warning against running production apps.
