### PR TITLE
Replace "Govt" with "Government"

### DIFF
--- a/CloudFoundry/config.toml
+++ b/CloudFoundry/config.toml
@@ -1,9 +1,9 @@
 baseurl = "http://documentation.trial.cf.paas.alphagov.co.uk/"
 MetaDataFormat = "yaml"
-title = "Govt PaaS"
+title = "Government PaaS"
 
 [params]
-  description = "Govt PaaS documentation"
+  description = "Government PaaS documentation"
   author = "Brett Ansley"
 
 

--- a/CloudFoundry/content/apps/apt-get.md
+++ b/CloudFoundry/content/apps/apt-get.md
@@ -6,4 +6,4 @@ title: Using apt-get
 weight: 10
 ---
 
-The Govt Trial Cloud Foundry does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`buildpack-multi`](http://documentation.trial.cf.paas.alphagov.co.uk/apps/multi-buildpack-deploys/).
+The Government Trial Cloud Foundry does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`buildpack-multi`](http://documentation.trial.cf.paas.alphagov.co.uk/apps/multi-buildpack-deploys/).

--- a/CloudFoundry/content/index.md
+++ b/CloudFoundry/content/index.md
@@ -2,7 +2,7 @@
 type: index
 ---
 
-# Govt PaaS Cloud Foundry Documentation
+# Government PaaS Cloud Foundry Documentation
 
 Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for managing the deployment of apps, services, and background tasks. GDS is planning to use it for many of our development and production systems as well as opening it up to any other agencies and departments who want to take advantage of it.
 


### PR DESCRIPTION
The name of the platform is Government PaaS so our documentation should reflect
this.
