### PR TITLE
Merge Create_CF_documentation to master

### DIFF
--- a/CloudFoundry/config.toml
+++ b/CloudFoundry/config.toml
@@ -1,9 +1,9 @@
 baseurl = "http://documentation.trial.cf.paas.alphagov.co.uk/"
 MetaDataFormat = "yaml"
-title = "Govt PaaS"
+title = "Government PaaS"
 
 [params]
-  description = "Govt PaaS documentation"
+  description = "Government PaaS documentation"
   author = "Brett Ansley"
 
 

--- a/CloudFoundry/content/apps/apt-get.md
+++ b/CloudFoundry/content/apps/apt-get.md
@@ -6,4 +6,4 @@ title: Using apt-get
 weight: 10
 ---
 
-The Govt Trial Cloud Foundry does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`buildpack-multi`](http://documentation.trial.cf.paas.alphagov.co.uk/apps/multi-buildpack-deploys/).
+The Government Trial Cloud Foundry does not allow the use of `sudo` inside of buildpacks. If your app depends on a library that is `apt-get` installable, use the CF-flavor of the [`apt-buildpack`](https://github.com/pivotal-cf-experimental/apt-buildpack). This works great with [`buildpack-multi`](http://documentation.trial.cf.paas.alphagov.co.uk/apps/multi-buildpack-deploys/).

--- a/CloudFoundry/content/apps/envvar.md
+++ b/CloudFoundry/content/apps/envvar.md
@@ -10,7 +10,7 @@ Environment variables are the means by which the Cloud Foundry runtime communica
 
 ## Setting environment variables in the manifest file
 
-You can set environment variables in your app by adding an `env` block to the manifest file. The `env` block consists of a heading, then one or more environment variable/value pairs.
+You can set environment variables in your app by adding an `env` block to the `manifest.yml` file for your app. The `env` block consists of a heading, then one or more environment variable/value pairs.
 
 For example:
 

--- a/CloudFoundry/content/apps/envvar.md
+++ b/CloudFoundry/content/apps/envvar.md
@@ -1,0 +1,42 @@
+---
+menu:
+  main:
+    parent: apps
+title: Environment Variables
+weight: -1
+---
+
+Environment variables are the means by which the Cloud Foundry runtime communicates with a deployed application about its environment. 
+
+## Setting environment variables in the manifest file
+
+You can set environment variables in your app by adding an `env` block to the manifest file. The `env` block consists of a heading, then one or more environment variable/value pairs.
+
+For example:
+
+```bash
+  ...
+  env:
+    RAILS_ENV: production
+    RACK_ENV: production
+```
+
+`cf push` deploys the application to a container on the server. The variables belong to the container environment.
+
+Environment variables interact with manifests in the following ways:
+
+- When you deploy an application for the first time, Cloud Foundry reads the variables described in the environment block of the manifest, and adds them to the environment of the container where the application is deployed.
+- When you stop and then restart an application, its environment variables persist.
+
+
+## Setting environment variables during runtime
+
+To set environment variables you can use the `cf set-env` command.
+
+```bash
+cf set-env APP-NAME ENV-NAME ENV-VALUE
+```
+
+Viewing the environment variables that have been set for an app can be done using `cf env` and you can unset variables using `cf unset-var`.
+
+Further documentation can be found [here](http://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html).

--- a/CloudFoundry/content/apps/flask.md
+++ b/CloudFoundry/content/apps/flask.md
@@ -95,10 +95,10 @@ applications:
 - name: APPNAME
   path: .
   timeout: 180
-  host: trial.cf.paas.alphagov.co.uk
+  host: flaskapp-${random-word}
 ```
 
-As you can see, it specifies the number of instances, the memory allocated to the application, and the application itself.
+As you can see, it specifies the number of instances, the memory allocated to the application, the application itself, and the host the application will be available at. In the above example, we add a random word to the host name to allow the example to work multiple times.
 
 ### Create the App
 

--- a/CloudFoundry/content/getting-started/concepts.md
+++ b/CloudFoundry/content/getting-started/concepts.md
@@ -101,7 +101,7 @@ Place your `manifest.yml` in the directory that contains the application files t
 
 ## Buildpacks
 
-All apps need to use a 'buildpack' specific to their language, which sets up dependencies for particular language stacks. There are standard buildpacks for most lanugages, and they will usually be auto-detected by CF. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the manifest (as below) or with the `-b` flag on the `cf push` command.
+All apps need to use a 'buildpack' specific to their language, which sets up dependencies for particular language stacks. There are standard buildpacks for most lanugages, and they will usually be auto-detected by CF. Using the standard buildpacks is strongly encouraged. In the rare case where the buildpack does not get detected correctly, or to use a custom buildpack, it can be specified in the [manifest](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) (as below) or with the `-b` flag on the `cf push` command.
 
     buildpack: python_buildpack
 

--- a/CloudFoundry/content/index.md
+++ b/CloudFoundry/content/index.md
@@ -2,7 +2,7 @@
 type: index
 ---
 
-# Govt PaaS Cloud Foundry Documentation
+# Government PaaS Cloud Foundry Documentation
 
 Welcome! Cloud Foundry is an open source Platform-as-a-Service (PaaS) system for managing the deployment of apps, services, and background tasks. GDS is planning to use it for many of our development and production systems as well as opening it up to any other agencies and departments who want to take advantage of it.
 


### PR DESCRIPTION
This repo currently has `Create_CF_documentation` as the default branch. We should use `master` because it's the standard for git repos. This PR brings `master` up-to-date with the other branch. Once merged I'll delete that branch and change the default in the repo's GitHub settings.
