### PR TITLE
[#108439336] Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# DEPRECATED
+
+This repository is no longer maintained. It was used for an alpha project by
+the Government PaaS team. You can follow what we're doing now at
+[alphagov/paas-developer-docs](https://github.com/alphagov/paas-developer-docs).


### PR DESCRIPTION
## What

When merged I will prefix the name of this repo with `paas-alpha-` and
transfer ownership to https://github.com/gds-attic

GitHub will redirect requests for the old name(s) to the new location.

NB: Unlike alphagov/cf-terraform, I'm referring to the new docs rather than
alphagov/paas-cf, because that may be what someone is specifically looking
for.
## How to review

Check that the README change makes sense.
## Who can review

Not @dcarley
